### PR TITLE
Remove and Restart CruxDB docker instance not running

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,15 @@
+CRUXDB_ERROR=$(shell docker ps -aq --filter name=CruxDB --filter status=paused --filter status=exited --filter status=dead)
+
+CRUXDB_OK=$(shell docker ps -aq --filter name=CruxDB --filter status=running)
+
 crux:
+ifneq ($(strip $(CRUXDB_ERROR)),)
+	docker rm -f $(CRUXDB_ERROR)
+endif
+
+ifeq ($(strip $(CRUXDB_OK)),)
 	docker run -d -p 3000:3000 --name CruxDB juxt/crux-standalone:20.09-1.11.0
+endif
 
 all: deps compile protocols
 
@@ -29,17 +39,17 @@ test: compile
 docs:
 	mix docs
 
-lint: format
-	mix credo --strict
-
 format:
 	mix format
+
+lint: format
+	mix credo --strict
 
 outdated:
 	mix hex.outdated
 
 spec:
-	 mix dialyzer --format dialyxir
+	mix dialyzer --format dialyxir
 
 publish:
 	mix hex.publish


### PR DESCRIPTION
This PR removes the `CruxDB` docker instance if found when ever we run `make crux`. Also misc style changes.

Before.
```
$ make crux
docker run -d -p 3000:3000 --name CruxDB juxt/crux-standalone:20.09-1.11.0
docker: Error response from daemon: Conflict. The container name "/CruxDB" is already in use by container "7abdb8a4f37923e61d75f106b2d5442c22e0d6e6472be28318d413f142f3ded7". You have to remove (or rename) that container to be able to reuse that name.
See 'docker run --help'.
make: *** [Makefile:2: crux] Error 125
```

After.
```
$ make crux
docker rm -f 7ea4a198b85e
7ea4a198b85e
docker run -d -p 3000:3000 --name CruxDB juxt/crux-standalone:20.09-1.11.0
a4c5767b7c97e34737eeee4dd31220d73768b3de68ffbf205f11ee4bed596d43
```